### PR TITLE
Make GHCJS yield back to the browser more frequently, so that the user's typing does not lag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CSS=vendor/codemirror/lib/codemirror.css	\
 		static/semantic.min.css
 
 compile:
-	cd src; ghcjs --make Main.hs -DGHCJS_BROWSER
+	cd src; ghcjs --make Main.hs -DGHCJS_BROWSER -DGHCJS_BUSY_YIELD=5 -DGHCJS_SCHED_QUANTUM=5
 	cat $(CSS) static/app.css > static/style.css
 	cat $(JS) src/Main.jsexe/all.js > static/app.js
 


### PR DESCRIPTION
The default SCHED_QUANTUM in GHCJS is 25ms, and the default BUSY_YIELD time is 500ms, so background threads cause the UI to pause for about half a second at a time.  This patch sets both times to 5ms.
